### PR TITLE
Problem: Invalid Markdown links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@ A containerized way to run the [Anacapa eDNA processing toolkit](https://github.
 ## Requirements
 
 - Access to a Linux computer (Mac/Windows planned but not ready yet)
-- [http://singularity.lbl.gov/docs-mount](Singularity) installed
-- [https://github.com/datproject/dat/#installing-the--dat-command-line-tool](Dat) installed
+- [Singularity](http://singularity.lbl.gov/docs-mount) installed
+- [Dat](https://github.com/datproject/dat/#installing-the--dat-command-line-tool) installed
 - Around 6GB of disk space
 
 ### 1. Install Singularity


### PR DESCRIPTION
The links for Singularity & Dat are invalid, because the address (parentheses) and link text (square brackets) parts of the link are transposed.

Solution: Swap parts